### PR TITLE
Inject rule set into Game

### DIFF
--- a/console_game.rb
+++ b/console_game.rb
@@ -3,11 +3,13 @@ require_relative 'lib/board'
 require_relative 'lib/player'
 require_relative 'lib/player_state'
 require_relative 'lib/transition'
+require_relative 'lib/rules/standard_rules'
 
 players = [Player.new('James'), Player.new('Sebastian')]
 player_states = players.map { |player| PlayerState.new(player) }
 board = Board.new([], 10)
-g = Game.new(board, player_states)
+rules = StandardRules.new
+g = Game.new(board, player_states, rules)
 
 until g.last_move_was_a_win
   print "It's your turn #{g.next_player}! Press any key to roll the dice: "

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -1,12 +1,14 @@
 require_relative 'player_state'
 
 class Game
-  def initialize(board, player_states)
+  def initialize(board, player_states, rules)
     @board = board
     @player_states = player_states
+    @rules = rules
   end
 
   def move_next_player(num_spaces)
+    return puts 'Invalid roll' unless @rules.roll_is_valid(num_spaces)
     current_index = current_state(next_player).index
     new_index = @board.compute_destination_index(current_index + num_spaces)
     @player_states << PlayerState.new(next_player, new_index)
@@ -21,16 +23,10 @@ class Game
   end
 
   def next_player
-    @player_states[-player_count].player
+    @rules.next_player(@player_states)
   end
 
   def current_state(player)
     @player_states.select { |p_state| p_state.player == player }.last
-  end
-
-  private
-
-  def player_count
-    @player_count ||= @player_states.uniq(&:player).size
   end
 end

--- a/lib/rules/rules_interface.rb
+++ b/lib/rules/rules_interface.rb
@@ -1,0 +1,9 @@
+class RulesInterface
+  def roll_is_valid(roll_num)
+    raise 'Not implemented'
+  end
+
+  def next_player(player_states)
+    raise 'Not implemented'
+  end
+end

--- a/lib/rules/standard_rules.rb
+++ b/lib/rules/standard_rules.rb
@@ -1,0 +1,12 @@
+require_relative 'rules_interface'
+
+class StandardRules < RulesInterface
+  def roll_is_valid(roll_num)
+    (1..6).cover?(roll_num)
+  end
+
+  def next_player(player_states)
+    player_count = player_states.uniq(&:player).size
+    player_states[-player_count].player
+  end
+end


### PR DESCRIPTION
Previously, a game could only be played one way (sequential turns, use any type of die). With these changes, turn order and the type of die can be specified as part of the rule set, allowing for different variants of snakes and ladders to be played. By injecting a rule set into the Game, we are also decoupling the Game from the way a game is to be played.