### PR TITLE
Add Die to handle rolls

### DIFF
--- a/console_game.rb
+++ b/console_game.rb
@@ -5,22 +5,26 @@ require_relative 'lib/player_state'
 require_relative 'lib/transition'
 require_relative 'lib/rules/standard_rules'
 require_relative 'lib/console_printer'
+require_relative 'lib/die'
 
 players = [Player.new('James'), Player.new('Sebastian')]
 player_states = players.map { |player| PlayerState.new(player) }
 board = Board.new([Transition.new(5, 50), Transition.new(87, 25)], 10)
-rules = StandardRules.new
+
+d6 = Die.new(6)
+rules = StandardRules.new(d6)
+
 g = Game.new(board, player_states, rules)
 p = ConsolePrinter.new(g)
 
 until g.last_move_was_a_win
+  player = g.next_player
   p.display_board
-  print "It's your turn #{g.next_player}! Press any key to roll the dice: "
+  print "It's your turn #{player}! Press any key to roll the dice: "
   gets.chomp
-  move = rand(1..6)
-  puts "You rolled a #{move}"
-  g.move_next_player(move)
+  g.move_next_player
+  puts "You rolled a #{g.last_roll(player)}"
 end
 
 p.display_board
-puts "#{g.previous_player} wins!"
+puts "#{player} wins!"

--- a/lib/die.rb
+++ b/lib/die.rb
@@ -1,0 +1,9 @@
+class Die
+  def initialize(sides)
+    @range = 1..sides
+  end
+
+  def roll
+    rand(@range)
+  end
+end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -20,6 +20,10 @@ class Game
     @move_history.last.index == @board.winning_index
   end
 
+  def last_roll(player)
+    current_state(player).last_roll
+  end
+
   def previous_player
     @move_history.last.player
   end

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -13,7 +13,7 @@ class Game
     roll_num = @rules.roll_dice
     current_index = current_state(next_player).index
     new_index = @board.compute_destination_index(current_index + roll_num)
-    @move_history << PlayerState.new(next_player, new_index)
+    @move_history << PlayerState.new(next_player, new_index, roll_num)
   end
 
   def last_move_was_a_win

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -9,10 +9,10 @@ class Game
     @rules = rules
   end
 
-  def move_next_player(num_spaces)
-    return puts 'Invalid roll' unless @rules.roll_is_valid(num_spaces)
+  def move_next_player
+    roll_num = @rules.roll_dice
     current_index = current_state(next_player).index
-    new_index = @board.compute_destination_index(current_index + num_spaces)
+    new_index = @board.compute_destination_index(current_index + roll_num)
     @move_history << PlayerState.new(next_player, new_index)
   end
 

--- a/lib/player_state.rb
+++ b/lib/player_state.rb
@@ -1,8 +1,9 @@
 class PlayerState
-  attr_reader :player, :index
+  attr_reader :player, :index, :last_roll
 
-  def initialize(player, index = 0)
+  def initialize(player, index = 0, last_roll = 0)
     @player = player
     @index = index
+    @last_roll = last_roll
   end
 end

--- a/lib/rules/standard_rules.rb
+++ b/lib/rules/standard_rules.rb
@@ -1,7 +1,11 @@
 require_relative 'rules_interface'
 
 class StandardRules < RulesInterface
-  def roll_is_valid(roll_num)
-    (1..6).cover?(roll_num)
+  def initialize(die)
+    @die = die
+  end
+
+  def roll_dice
+    @die.roll
   end
 end


### PR DESCRIPTION
Rolling is now handled internally via a `Die` object. `Game` no longer accepts a value as to how far to move a player; the Die object determines how far a player should move. As a result, users of the game class can no longer input bad moves, as there is no input in the first place.